### PR TITLE
Fix "Timer is still pending" error when running tests

### DIFF
--- a/lib/adaptive_scrollbar.dart
+++ b/lib/adaptive_scrollbar.dart
@@ -8,6 +8,7 @@ import 'package:rxdart/rxdart.dart';
 
 // Scrollbar positions.
 enum ScrollbarPosition { right, bottom, left, top }
+
 // Scroll direction to the nearest click on bottom.
 enum ToClickDirection { up, down }
 
@@ -214,11 +215,7 @@ class _AdaptiveScrollbarState extends State<AdaptiveScrollbar> {
         LayoutBuilder(
             builder: (BuildContext context, BoxConstraints constraints) {
           if (firstRender) {
-            Future.delayed(Duration.zero, () async {
-              setState(() {
-                firstRender = false;
-              });
-            });
+            Future.microtask(() => setState(() => firstRender = false));
           }
           return !widget.controller.hasClients ||
                   widget.controller.position.maxScrollExtent == 0
@@ -373,6 +370,7 @@ class _ScrollSliderState extends State<ScrollSlider> {
 
   @override
   void dispose() {
+    timer.cancel();
     streamSubscriptionScroll.cancel();
     streamSubscriptionClick.cancel();
     super.dispose();


### PR DESCRIPTION
This PR fixes an exception that is thrown when running widget tests.

Using `Future.delayed` inside the `build()` function + not cancelling the `Timer` instance on the widget disposal don't play well with flutter tests.

When testing the current code the following exception will be thrown:

```
══╡ EXCEPTION CAUGHT BY FLUTTER TEST FRAMEWORK ╞════════════════════════════════════════════════════
The following assertion was thrown running a test:
A Timer is still pending even after the widget tree was disposed.
'package:flutter_test/src/binding.dart':
Failed assertion: line 1518 pos 12: '!timersPending'
```

Watching the tests logs you will find a hint:

```
Pending timers:
Timer (duration: 0:00:00.400000, periodic: false), created:
#0      new FakeTimer._ (package:fake_async/fake_async.dart:308:62)
#1      FakeAsync._createTimer (package:fake_async/fake_async.dart:252:27)
#2      FakeAsync.run.<anonymous closure> (package:fake_async/fake_async.dart:185:19)
#5      new _ScrollSliderState (package:adaptive_scrollbar/adaptive_scrollbar.dart:348:17)
#6      ScrollSlider.createState (package:adaptive_scrollbar/adaptive_scrollbar.dart:319:39)
#7      new StatefulElement (package:flutter/src/widgets/framework.dart:5555:25)
```
<img width="800" alt="Screenshot 2024-02-23 at 17 33 19" src="https://github.com/rulila52/adaptive-scrollbar/assets/406594/fdedc7ad-b945-4adf-992f-a4d5bbbbac45">

The exception can be reproduced by replacing the main function in `...example/test/widget_test.dart` by the following:

```
void main() {
  testWidgets('Simple test', (WidgetTester tester) async {
    await tester.pumpWidget(MyApp());
  });
}
```

Running the same test with the changes in this PR will result in passing tests ✅